### PR TITLE
Remove documentation for internal registers

### DIFF
--- a/example/c/ARM/STM/Click_ATA6570_STM.cp
+++ b/example/c/ARM/STM/Click_ATA6570_STM.cp
@@ -126,14 +126,6 @@ extern const uint8_t _ATA6570_WKESR ;
 
 extern const uint8_t _ATA6570_DIDR ;
 
-extern const uint8_t _ATA6570_FUDI ;
-extern const uint8_t _ATA6570_FUDO ;
-extern const uint8_t _ATA6570_FUSEL ;
-extern const uint8_t _ATA6570_BGCAL ;
-extern const uint8_t _ATA6570_FRCCAL ;
-extern const uint8_t _ATA6570_HRCCALL ;
-extern const uint8_t _ATA6570_HRCCALH ;
-
 
 
 extern const uint8_t _ATA6570_OPMODE_NORMAL ;

--- a/example/c/PIC/Click_ATA6570_PIC.cp
+++ b/example/c/PIC/Click_ATA6570_PIC.cp
@@ -111,13 +111,6 @@ extern const uint8_t _ATA6570_WKESR ;
 
 extern const uint8_t _ATA6570_DIDR ;
 
-extern const uint8_t _ATA6570_FUDI ;
-extern const uint8_t _ATA6570_FUDO ;
-extern const uint8_t _ATA6570_FUSEL ;
-extern const uint8_t _ATA6570_BGCAL ;
-extern const uint8_t _ATA6570_FRCCAL ;
-extern const uint8_t _ATA6570_HRCCALL ;
-extern const uint8_t _ATA6570_HRCCALH ;
 
 
 

--- a/library/__ata6570_driver.c
+++ b/library/__ata6570_driver.c
@@ -73,14 +73,6 @@ const uint8_t _ATA6570_WKESR      = 0x64;
 
 const uint8_t _ATA6570_DIDR       = 0x7E;
 
-const uint8_t _ATA6570_FUDI       = 0x70;
-const uint8_t _ATA6570_FUDO       = 0x71;
-const uint8_t _ATA6570_FUSEL      = 0x72;
-const uint8_t _ATA6570_BGCAL      = 0x73;
-const uint8_t _ATA6570_FRCCAL     = 0x74;
-const uint8_t _ATA6570_HRCCALL    = 0x75;
-const uint8_t _ATA6570_HRCCALH    = 0x76;
-
 const uint8_t _ATA6570_OPMODE_SLEEP  = 0x01; 
 const uint8_t _ATA6570_OPMODE_STBY   = 0x04;
 const uint8_t _ATA6570_OPMODE_NORMAL = 0x07;

--- a/library/__ata6570_driver.h
+++ b/library/__ata6570_driver.h
@@ -105,13 +105,6 @@ extern const uint8_t _ATA6570_WKESR   ;  /**< WAKE Event Status Register */
 
 extern const uint8_t _ATA6570_DIDR    ;  /**< Device ID Register */
 
-extern const uint8_t _ATA6570_FUDI    ;
-extern const uint8_t _ATA6570_FUDO    ;
-extern const uint8_t _ATA6570_FUSEL   ;
-extern const uint8_t _ATA6570_BGCAL   ;
-extern const uint8_t _ATA6570_FRCCAL  ;
-extern const uint8_t _ATA6570_HRCCALL ;
-extern const uint8_t _ATA6570_HRCCALH ;
                                                                        /** @} */
 /** @defgroup ATA6570_OPMODE ATA6570 Operation Modes */                /** @{ */
 


### PR DESCRIPTION
These internal register should not be exposed. They are not meant to be read or written.